### PR TITLE
Improve MT5 initialization reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository provides a simple trading assistant that listens to messages fro
     MT5_LOGIN=<account>
     MT5_PASSWORD=<password>
     MT5_SERVER=<broker server>
+    MT5_PATH=<optional path to terminal executable>
     RISK_PERCENT=1.0
     ```
 

--- a/bot.py
+++ b/bot.py
@@ -86,15 +86,25 @@ def connect_mt5() -> bool:
         logger.error("MetaTrader5 package is not installed.")
         return False
 
-    if mt5.initialize():
+    path = os.getenv("MT5_PATH", "")
+    kwargs = {"path": path} if path else {}
+
+    if mt5.initialize(**kwargs):
         return True
+    else:
+        code, msg = mt5.last_error()
+        logger.warning("Initial MT5 initialize failed: %s (%s)", code, msg)
 
     login = int(os.getenv("MT5_LOGIN", "0"))
     password = os.getenv("MT5_PASSWORD", "")
     server = os.getenv("MT5_SERVER", "")
     if login and password and server:
-        if mt5.initialize(login=login, password=password, server=server):
+        kwargs.update({"login": login, "password": password, "server": server})
+        if mt5.initialize(**kwargs):
             return True
+        else:
+            code, msg = mt5.last_error()
+            logger.warning("MT5 initialize with credentials failed: %s (%s)", code, msg)
 
     logger.error("Failed to initialize MT5")
     return False


### PR DESCRIPTION
## Summary
- better error messages when connecting to MT5
- allow specifying terminal path via `MT5_PATH`

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt` *(fails: no matching distribution for MetaTrader5)*

------
https://chatgpt.com/codex/tasks/task_e_686a5a49e018832e9c559ddad635d9cc