### PR TITLE
Add symbol caching and remove index suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ vendor/
 # Ignore venv
 myenv/
 venv/
+open_positions.json
+available_symbols.json


### PR DESCRIPTION
## Summary
- save and load full MT5 symbol list to `available_symbols.json`
- drop automatic `INDEX` suffix when parsing signals
- validate parsed symbols against cached list
- refresh symbols on startup and in test trade
- ignore `available_symbols.json`

## Testing
- `python -m py_compile bot.py`
- `python bot.py --help | head`


------
https://chatgpt.com/codex/tasks/task_e_686bb3af0980832e829dafd3eda5aa4f